### PR TITLE
Fix Markdown not showing headings in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,9 @@
-#Zorba - The NoSQL  Processor
+# Zorba - The NoSQL  Processor
 [![Circle CI](https://circleci.com/gh/28msec/zorba.svg?style=svg)](https://circleci.com/gh/28msec/zorba) 
 
 http://zorba.io/
 
-##Docker Container
+## Docker Container
 A container with the zorba binary is available at https://registry.hub.docker.com/u/fcavalieri/zorba/
 
 Below are examples of Zorba executed via Docker:
@@ -18,9 +18,9 @@ You can also mount a local folder that contains your queries. The image exposes 
 docker run -v /home/fcavalieri/myqueries:/queries zorba -q foo.xq -f
 ```
 
-##Documentation
+## Documentation
 http://zorba.io/documentation/latest
 
-##Support
+## Support
 If you want to be informed about new code releases, bug fixes and general news and information about the Zorba NoSQL Processor, subscribe to the Zorba Users mailing list [zorba-io-users@googlegroups.com](mailto:zorba-io-users@googlegroups.com)
 


### PR DESCRIPTION
Markdown headings should be spaces after the number sign (#) like `# Heading`, not `#Heading`.